### PR TITLE
Added ability to run a single test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ var APP_NAME = 'translationStudio',
     
 gulp.task('test', function () {
     return gulp.src(UNIT_TEST_FILES, { read: false })
-        .pipe(mocha({reporter: 'spec'}));
+        .pipe(mocha({reporter: 'spec', grep: (argv.grep || argv.g)}));
 });
     
 gulp.task('jscs', function () {


### PR DESCRIPTION
Example:
```gulp test --grep '@Configurator'```
or
```gulp test -g '@Configurator'```

The grep option (--grep or -g) searches the describe() and it() functions in the unit tests. Use this option to run a single test or a single test suite.