### PR TITLE
Develop

### DIFF
--- a/app/elements/ts-translate/ts-chunk-mode/ts-chunk-card.html
+++ b/app/elements/ts-translate/ts-chunk-mode/ts-chunk-card.html
@@ -83,11 +83,10 @@
     <template>
 
         <div id="contain">
-            <ts-source-chunk id="srccard" class="top" on-tap="srctop" chunk="[[chunk]]"></ts-source-chunk>
-            <ts-target-edit chunkmode id="transcard" class="bottom" on-tap="transtop" chunk="{{chunk}}" on-setheight="setheight"></ts-target-edit>
+            <ts-source-chunk id="srccard" class$="[[sourceclass(chunk.state.chunk)]]" on-tap="srctop" chunk="[[chunk]]"></ts-source-chunk>
+            <ts-target-edit chunkmode id="transcard" class$="[[transclass(chunk.state.chunk)]]" on-tap="transtop" chunk="{{chunk}}" on-setheight="setheight"></ts-target-edit>
         </div>
 
-        <iron-signals on-iron-signal-reset="reset"></iron-signals>
         <iron-signals on-iron-signal-setheight="setheight"></iron-signals>
 
     </template>
@@ -112,13 +111,12 @@
             }
         },
 
-        reset: function () {
-            var trans = this.$.transcard;
-            var src = this.$.srccard;
-            trans.classList.remove("top");
-            src.classList.add("top");
-            trans.classList.add("bottom");
-            src.classList.remove("bottom");
+        sourceclass: function (state) {
+            return state ? 'top' : 'bottom';
+        },
+
+        transclass: function (state) {
+            return state ? 'bottom' : 'top';
         },
 
         setheight: function () {
@@ -134,17 +132,17 @@
         transtop: function () {
             var trans = this.$.transcard;
             var src = this.$.srccard;
+            var mythis = this;
+            var id = this.chunk.meta.chapterid + "-" + this.chunk.meta.frameid;
 
-            if(!trans.classList.contains("top")) {
+            if(this.chunk.state.chunk) {
                 trans.classList.add("up");
                 src.classList.add("down");
                 setTimeout(function () {
                     trans.classList.remove("up");
                     src.classList.remove("down");
-                    trans.classList.add("top");
-                    src.classList.add("bottom");
-                    src.classList.remove("top");
-                    trans.classList.remove("bottom");
+                    mythis.set('chunk.state.chunk', false);
+                    mythis.fire('iron-signal', {name: 'updatestate', data: {id: id, mode: "chunk", value: false}});
                 }, 1000);
             }
         },
@@ -152,17 +150,17 @@
         srctop: function () {
             var trans = this.$.transcard;
             var src = this.$.srccard;
+            var mythis = this;
+            var id = this.chunk.meta.chapterid + "-" + this.chunk.meta.frameid;
 
-            if(!src.classList.contains("top")) {
+            if(!this.chunk.state.chunk) {
                 trans.classList.add("down");
                 src.classList.add("up");
                 setTimeout(function () {
                     trans.classList.remove("down");
                     src.classList.remove("up");
-                    src.classList.add("top");
-                    trans.classList.add("bottom");
-                    trans.classList.remove("top");
-                    src.classList.remove("bottom");
+                    mythis.set('chunk.state.chunk', true);
+                    mythis.fire('iron-signal', {name: 'updatestate', data: {id: id, mode: "chunk", value: true}});
                 }, 1000);
             }
         },

--- a/app/elements/ts-translate/ts-read-mode/ts-read-card.html
+++ b/app/elements/ts-translate/ts-read-mode/ts-read-card.html
@@ -83,11 +83,10 @@
     <template>
 
         <div id="contain">
-            <ts-source-card id="srccard" class="top" on-tap="srctop" chunk="[[chunk]]"></ts-source-card>
-            <ts-target-view id="transcard" class="bottom" on-tap="transtop" chunk="[[chunk]]"></ts-target-view>
+            <ts-source-card id="srccard" class$="[[sourceclass(chunk.state)]]" on-tap="srctop" chunk="[[chunk]]"></ts-source-card>
+            <ts-target-view id="transcard" class$="[[transclass(chunk.state)]]" on-tap="transtop" chunk="[[chunk]]"></ts-target-view>
         </div>
 
-        <iron-signals on-iron-signal-reset="reset"></iron-signals>
         <iron-signals on-iron-signal-setheight="setheight"></iron-signals>
 
     </template>
@@ -107,6 +106,14 @@
             }
         },
 
+        sourceclass: function (state) {
+            return state ? 'top' : 'bottom';
+        },
+
+        transclass: function (state) {
+            return state ? 'bottom' : 'top';
+        },
+
         setheight: function () {
             var trans = this.$.transcard;
             var src = this.$.srccard;
@@ -117,29 +124,20 @@
             this.fire('updateheight');
         },
 
-        reset: function () {
-            var trans = this.$.transcard;
-            var src = this.$.srccard;
-            trans.classList.remove("top");
-            src.classList.add("top");
-            trans.classList.add("bottom");
-            src.classList.remove("bottom");
-        },
-
         transtop: function () {
             var trans = this.$.transcard;
             var src = this.$.srccard;
+            var mythis = this;
+            var id = this.chunk.chapterid;
 
-            if(!trans.classList.contains("top")) {
+            if(this.chunk.state) {
                 trans.classList.add("up");
                 src.classList.add("down");
                 setTimeout(function () {
                     trans.classList.remove("up");
                     src.classList.remove("down");
-                    trans.classList.add("top");
-                    src.classList.add("bottom");
-                    src.classList.remove("top");
-                    trans.classList.remove("bottom");
+                    mythis.set('chunk.state', false);
+                    mythis.fire('iron-signal', {name: 'updatestate', data: {id: id, mode: "read", value: false}});
                 }, 1000);
             }
         },
@@ -147,17 +145,17 @@
         srctop: function () {
             var trans = this.$.transcard;
             var src = this.$.srccard;
+            var mythis = this;
+            var id = this.chunk.chapterid;
 
-            if(!src.classList.contains("top")) {
+            if(!this.chunk.state) {
                 trans.classList.add("down");
                 src.classList.add("up");
                 setTimeout(function () {
                     trans.classList.remove("down");
                     src.classList.remove("up");
-                    src.classList.add("top");
-                    trans.classList.add("bottom");
-                    trans.classList.remove("top");
-                    src.classList.remove("bottom");
+                    mythis.set('chunk.state', true);
+                    mythis.fire('iron-signal', {name: 'updatestate', data: {id: id, mode: "read", value: true}});
                 }, 1000);
             }
         },

--- a/app/elements/ts-translate/ts-read-mode/ts-read-mode.html
+++ b/app/elements/ts-translate/ts-read-mode/ts-read-mode.html
@@ -160,18 +160,8 @@
 
         setlocation: function () {
             var list = this.$.readlist;
-            var card;
-            var found = false;
-            var i = 0;
-
-            while (i < 10000 && !found) {
-                list.scrollToIndex(i);
-                card = document.getElementById(this.modename + i);
-                if (card.chunk.chapter === this.modestatus.chapter) {
-                    found = true;
-                }
-                i++;
-            }
+            var index = parseInt(this.modestatus.chapter) - 1;
+            list.scrollToIndex(index);
         },
 
         createid: function (index) {

--- a/app/elements/ts-translate/ts-review-mode/ts-review-card.html
+++ b/app/elements/ts-translate/ts-review-mode/ts-review-card.html
@@ -44,17 +44,15 @@
         <div id="contain">
             <ts-source-chunk id="left" reviewmode chunk="[[chunk]]"></ts-source-chunk>
             <div id="middle">
-                <template is="dom-if" if="{{selected}}">
-                    <ts-target-review selected="{{selected}}" chunk="{{chunk}}"></ts-target-review>
+                <template is="dom-if" if="{{chunk.state.review}}">
+                    <ts-target-review chunk="{{chunk}}" on-setheight="setheight"></ts-target-review>
                 </template>
-                <template is="dom-if" if="{{!selected}}">
-                    <ts-target-edit selected="{{selected}}" chunk="{{chunk}}" on-setheight="setheight"></ts-target-edit>
+                <template is="dom-if" if="{{!chunk.state.review}}">
+                    <ts-target-edit chunk="{{chunk}}" on-setheight="setheight"></ts-target-edit>
                 </template>
             </div>
             <ts-resource-card id="right" chunk="[[chunk]]"></ts-resource-card>
         </div>
-
-        <iron-signals on-iron-signal-reset="reset"></iron-signals>
 
 	</template>
 
@@ -75,16 +73,8 @@
                 type: Object,
                 value: {},
                 notify: true
-            },
-            selected: {
-                type: Boolean,
-                value: true
             }
 		},
-
-        reset: function () {
-            this.selected = true;
-        },
 
         setheight: function () {
             this.fire('updateheight');

--- a/app/elements/ts-translate/ts-target/ts-target-edit.html
+++ b/app/elements/ts-translate/ts-target/ts-target-edit.html
@@ -104,11 +104,6 @@
                 type: Object,
                 value: {},
                 notify: true
-            },
-            selected: {
-                type: Boolean,
-                value: true,
-                notify: true
             }
 		},
 
@@ -154,7 +149,10 @@
         },
 
         review: function () {
-            this.selected = true;
+            var id = this.chunk.meta.chapterid + "-" + this.chunk.meta.frameid;
+            this.set('chunk.state.review', true);
+            this.fire('setheight');
+            this.fire('iron-signal', {name: 'updatestate', data: {id: id, mode: "review", value: true}});
         },
 
         input: function () {

--- a/app/elements/ts-translate/ts-target/ts-target-review.html
+++ b/app/elements/ts-translate/ts-target/ts-target-review.html
@@ -127,11 +127,6 @@
                 type: Object,
                 value: {},
                 notify: true
-            },
-            selected: {
-                type: Boolean,
-                value: true,
-                notify: true
             }
         },
 
@@ -239,7 +234,10 @@
         },
 
         edit: function () {
-            this.selected = false;
+            var id = this.chunk.meta.chapterid + "-" + this.chunk.meta.frameid;
+            this.set('chunk.state.review', false);
+            this.fire('setheight');
+            this.fire('iron-signal', {name: 'updatestate', data: {id: id, mode: "review", value: false}});
         },
 
 		ready: function() {

--- a/app/elements/ts-translate/ts-translate.html
+++ b/app/elements/ts-translate/ts-translate.html
@@ -147,6 +147,7 @@
         <iron-signals on-iron-signal-opennodata="opennodata"></iron-signals>
         <iron-signals on-iron-signal-opensource="opensource"></iron-signals>
         <iron-signals on-iron-signal-savetofile="savetofile"></iron-signals>
+        <iron-signals on-iron-signal-updatestate="updatestate"></iron-signals>
 
     </template>
 
@@ -250,8 +251,16 @@
             this.$.reviewmode.notifyResize();
         },
 
+        updatestate: function (event, data) {
+            var id = data.id;
+            var mode = data.mode;
+            this.currentproject.state[id][mode] = data.value;
+        },
+
         loadnewproject: function (event, data) {
             var blank = [];
+            var blankstate = {};
+            this.set('currentproject.state', blankstate);
             this.set('currentproject.translation', blank);
             this.set('currentproject.data', data.projdata);
             this.savetofile();
@@ -261,7 +270,9 @@
 
         loadproject: function (event, data) {
             var mythis = this;
+            var blankstate = {};
             mythis.set('currentproject.data', data.projdata);
+            mythis.set('currentproject.state', blankstate);
             App.projectsManager.loadTargetTranslation(data.projdata).then(function (translation) {
                 mythis.set('rawdata', translation);
                 mythis.pullsource();
@@ -412,7 +423,7 @@
                 source.push(srcchunk);
 
                 var rawdata = this.rawdata[chapterid + '-' + frameid];
-                if (!rawdata) {
+                if (rawdata === undefined) {
                     transchunk = {content: "", completed: false, meta: meta};
                 } else {
                     transchunk = {content: rawdata.content, completed: rawdata.completed, meta: meta};
@@ -543,7 +554,6 @@
             chunk.classList.add("hide");
             review.classList.add("hide");
             nosource.classList.add("hide");
-            mythis.fire('iron-signal', {name: 'reset'});
 
             if (sources !== undefined && sources.length !== 0) {
                 setTimeout(function() {
@@ -597,8 +607,20 @@
             var source = this.currentproject.source;
             var projectdata = this.currentproject.data;
 
+            for (var i = 0; i < translation.length; i++) {
+                var chapterid = translation[i].meta.chapterid;
+                var frameid = translation[i].meta.frameid;
+                var statedata = this.currentproject.state[chapterid + '-' + frameid];
+                if (statedata === undefined) {
+                    translation[i].state = {chunk: true, review: true};
+                    this.currentproject.state[chapterid + '-' + frameid] = {chunk: true, review: true};
+                } else {
+                    translation[i].state = statedata;
+                }
+            }
+
             transdata.data = translation.map(function(chunk, index){
-                return {transcontent: chunk.content, completed: chunk.completed, data: projectdata, index: index};
+                return {transcontent: chunk.content, completed: chunk.completed, data: projectdata, index: index, state: chunk.state};
             });
             srcdata.data = source.map(function(chunk){
                 return {srccontent: chunk.content, meta: chunk.meta, notes: chunk.notes, words: chunk.words, questions: chunk.questions};
@@ -619,6 +641,7 @@
             var translation = this.currentproject.translation;
             var source = this.currentproject.source;
             var projectdata = this.currentproject.data;
+            var mythis = this;
 
             _.forEach(_.groupBy(translation, function(chunks) {
                 return chunks.meta.chapter;
@@ -641,12 +664,22 @@
                 var chapcontent = "";
                 var chapter = parseInt(chap);
                 var chapterref = "";
+                var chapterid = "";
+                var chapstate = true;
 
                 _.forEach(data, function (chunk) {
                     chapcontent += chunk.content + " ";
                     chapterref = chunk.meta.chapterref;
+                    chapterid = chunk.meta.chapterid;
                 });
-                srcchapters.push({chapter: chapter, srccontent: chapcontent, chapterref: chapterref});
+
+                var chapterstatedata = mythis.currentproject.state[chapterid];
+                if (chapterstatedata === undefined) {
+                    mythis.currentproject.state[chapterid] = {read: true};
+                } else {
+                    chapstate = chapterstatedata.read;
+                }
+                srcchapters.push({chapter: chapter, srccontent: chapcontent, chapterref: chapterref, chapterid: chapterid, state: chapstate});
             });
 
             transdata.data = transchapters;


### PR DESCRIPTION
These changes fix a problem with the iron lists.  Previously the "state" of the cards (source on top or bottom, etc) was not bound to the card and was getting re-used as you scrolled down the iron list.  Now it remembers the state of each card and keeps it intact when scrolling, changing modes, and even changing sources.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-desktop/189)
<!-- Reviewable:end -->
