### PR TITLE
Exporting

### DIFF
--- a/app/js/projects.js
+++ b/app/js/projects.js
@@ -305,6 +305,7 @@ function ProjectsManager(query, configurator) {
             console.log("Exporting File", translation, meta, filename);
             // validate input
             if(filename === null || filename === '') {
+                console.log('the filename is empty');
                 return Promise.reject();
             }
 
@@ -368,10 +369,13 @@ function ProjectsManager(query, configurator) {
                         resolve(true);
                     } else {
                         // we don't support anything but dokuwiki right now
+                        console.log('we only support exporting the defaul format (dokuwiki) for now');
                         resolve(false);
                     }
                 } else {
                     // TODO: support exporting other target translation types if needed e.g. notes, words, questions
+                    console.log('we do not support exporting that project type yet.');
+                    reject();
                 }
             });
         },


### PR DESCRIPTION
some bug fixes and additional logging.

@cdwhitfield73 there's currently a bug where the filename is sometimes not passed to the export method. I seem to be able to export successfully once while the app is open but exporting a second time will result in the filename being empty. This appears to be a disconnect between the ui and the `exportTranslation`. Could you take a look at it?

For example: start the app, open publishing for an obs text translation, click export to file, then try exporting a second time. That's when I get the error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-desktop/246)
<!-- Reviewable:end -->
