### PR TITLE
Setup to handle alternate project variants

### DIFF
--- a/app/elements/ts-home/ts-home.html
+++ b/app/elements/ts-home/ts-home.html
@@ -215,6 +215,10 @@
             padding: 0 50px;
         }
 
+        .space {
+            padding-left: 5px;
+        }
+
     </style>
 
     <template>
@@ -251,7 +255,7 @@
                                     <div class="left" on-tap="openproject">
                                         <span class="smallspan"><iron-icon class="smallicon" icon$="[[checkicon(proj.project_id)]]"></iron-icon></span>
                                         <span class="bigspan">[[proj.project_name]]</span>
-                                        <span class="smallspan smalltext">[[proj.type_name]]</span>
+                                        <span class="smallspan smalltext"><span>[[proj.type_name]]</span><span class="space">[[proj.resource_id]]</span></span>
                                         <span class="smalltext bigspan">[[proj.target_language.name]]</span>
                                         <span class="smallspan"><ts-completion-icon percent="[[proj.completion]]"></ts-completion-icon></span>
                                     </div>

--- a/app/elements/ts-main/ts-dashboard.html
+++ b/app/elements/ts-main/ts-dashboard.html
@@ -369,9 +369,18 @@
               } else if (list[i].project_type === "tq") {
                   list[i].type_name = "Questions";
               }
+              if (list[i].resource_id === undefined) {
+                  if (list[i].project_type === "text") {
+                      list[i].resource_id = "ulb";
+                  } else {
+                      list[i].resource_id = "";
+                  }
+              }
               var typeext = "";
               if (list[i].project_type !== "text") {
                   typeext = "_" + list[i].project_type;
+              } else if (list[i].resource_id !== "ulb") {
+                  typeext = "_" + list[i].resource_id;
               }
               var fullname = list[i].project_id + typeext + "-" + list[i].target_language.id;
               list[i].basename = list[i].project_id + "-" + list[i].target_language.id;

--- a/app/elements/ts-new/ts-book-menu.html
+++ b/app/elements/ts-new/ts-book-menu.html
@@ -129,7 +129,7 @@
 
       store: function(e) {
           this.project = e.model.project;
-          this.fire('iron-signal', {name: 'checkproject'});
+          this.fire('iron-signal', {name: 'createtypes'});
           this.selected = this.selected + 1;
       },
 

--- a/app/elements/ts-new/ts-new.html
+++ b/app/elements/ts-new/ts-new.html
@@ -86,7 +86,7 @@
             <ts-language-menu id="languages" selected="{{selected}}" language="{{language}}"></ts-language-menu>
             <ts-project-menu selected="{{selected}}" category="{{category}}" project="{{project}}"></ts-project-menu>
             <ts-book-menu selected="{{selected}}" category="[[category]]" project="{{project}}"></ts-book-menu>
-            <ts-type-menu selected="{{selected}}" category="[[category]]" project="[[project]]" allowed="[[allowed]]" type="{{type}}" on-create="createproject"></ts-type-menu>
+            <ts-type-menu selected="{{selected}}" language="[[language]]" category="[[category]]" project="[[project]]" type="{{type}}" projectlist="[[projectlist]]" on-create="createproject"></ts-type-menu>
         </neon-animated-pages>
 
         <paper-dialog id="popup" modal="true" entry-animation="scale-up-animation" exit-animation="scale-down-animation">
@@ -98,8 +98,6 @@
                 <paper-button dialog-dismiss>Ok</paper-button>
             </div>
         </paper-dialog>
-
-        <iron-signals on-iron-signal-checkproject="checkproject"></iron-signals>
 
     </template>
 
@@ -137,10 +135,6 @@
                 type: Object,
                 value: {}
             },
-            allowed: {
-                type: Object,
-                value: {}
-            },
             type: {
                 type: Object,
                 value: {}
@@ -173,30 +167,6 @@
             this.$.languages.notifyResize();
         },
 
-        checkproject: function () {
-            var project = this.project;
-            var language = this.language;
-            var projectarray = this.projectlist;
-            var basename = project.slug + "-" + language.id;
-            this.set('allowed', {text: true, tn: false, tq: false});
-
-            for (var i = 0; i < projectarray.length; i++) {
-                if (projectarray[i].basename === basename && projectarray[i].project_type === "text") {
-                    this.set('allowed', {text: false, tn: true, tq: true});
-                }
-            }
-            for (i = 0; i < projectarray.length; i++) {
-                if (projectarray[i].basename === basename) {
-                    if (projectarray[i].project_type === "tn") {
-                        this.set('allowed.tn', false);
-                    }
-                    if (projectarray[i].project_type === "tq") {
-                        this.set('allowed.tq', false);
-                    }
-                }
-            }
-        },
-
         createproject: function () {
             var project = this.project;
             var language = this.language;
@@ -204,18 +174,11 @@
             var typeext = "";
             var projectarray = this.projectlist;
             var popup = this.$.popup;
-            var typename;
 
-            if (type === "text") {
-                typename = "Text";
-            } else if (type === "tn") {
-                typename = "Notes";
-            } else if (type === "tq") {
-                typename = "Questions";
-            }
-
-            if (type !== "text") {
-                typeext = "_" + type;
+            if (type.code !== "text") {
+                typeext = "_" + type.code;
+            } else if (type.resource !== "ulb") {
+                typeext = "_" + type.resource;
             }
 
             var fullname = project.slug + typeext + "-" + language.id;
@@ -229,13 +192,13 @@
                 }
             }
 
-            if (!this.allowed[type]) {
+            if (!type.allowed) {
                 this.set('options', {title: "No Translation", body: "Cannot start this project until a standard translation project exists"});
                 popup.open();
                 return;
             }
 
-            var newprojdata = {"project_id": project.slug, "project_name": project.name, "type_name": typename, "fullname": fullname, "basename": basename, "project_type": type, "target_language": language, "translators": [], "sources": [], "completion": 0, "currentsource": null};
+            var newprojdata = {"project_id": project.slug, "project_name": project.name, "type_name": type.name, "fullname": fullname, "basename": basename, "project_type": type.code, "resource_id": type.resource, "target_language": language, "translators": [], "sources": [], "completion": 0, "currentsource": null};
             this.fire('iron-signal', {name: 'loadnewproject', data: {projdata: newprojdata}});
             this.animationConfig.exit.name = 'slide-left-animation';
             this.route = "translate";

--- a/app/elements/ts-new/ts-project-menu.html
+++ b/app/elements/ts-new/ts-project-menu.html
@@ -153,7 +153,7 @@
           this.category = e.model.category;
           if (this.category.name === "Open Bible Stories") {
               this.project = this.category.data[0];
-              this.fire('iron-signal', {name: 'checkproject'});
+              this.fire('iron-signal', {name: 'createtypes'});
               this.selected = this.selected + 2;
           } else {
               this.selected = this.selected + 1;

--- a/app/elements/ts-new/ts-type-menu.html
+++ b/app/elements/ts-new/ts-type-menu.html
@@ -102,7 +102,7 @@
       <div id="contain">
           <iron-list items="[[typelist]]" as="type">
               <template>
-                  <div class$="[[checkclass(type.code, allowed.*)]]" on-tap="store">
+                  <div class$="[[checkclass(type.allowed)]]" on-tap="store">
                       <div>
                           <span>[[type.name]]</span>
                       </div>
@@ -110,6 +110,8 @@
               </template>
           </iron-list>
       </div>
+
+      <iron-signals on-iron-signal-createtypes="createtypes"></iron-signals>
 
   </template>
 
@@ -126,6 +128,10 @@
               value: 0,
               notify: true
           },
+          language: {
+              type: Object,
+              value: {}
+          },
           category: {
               type: Object,
               value: {}
@@ -134,9 +140,9 @@
               type: Object,
               value: {}
           },
-          allowed: {
-              type: Object,
-              value: {}
+          projectlist: {
+              type: Array,
+              value: []
           },
           obs: {
               type: Boolean,
@@ -149,7 +155,7 @@
           },
           typelist: {
               type: Array,
-              value: [{name: "Text", code: "text"}, {name: "Notes", code: "tn"}, {name: "Questions", code: "tq"}]
+              value: []
           }
       },
 
@@ -161,8 +167,45 @@
           'checkobs(category.name)'
       ],
 
-      checkclass: function (code) {
-          return this.allowed[code] ? 'row' : 'row unavailable';
+      createtypes: function () {
+          var project = this.project.slug;
+          var sources = App.projectsManager.sources;
+          var selections = _.filter(sources, {'project': project, 'level': 3, 'lc': 'en'});
+          var typearray = [];
+          var language = this.language;
+          var projectarray = this.projectlist;
+          var basename = project + "-" + language.id;
+          var standardexists = false;
+
+          for (var i = 0; i < projectarray.length; i++) {
+              if (projectarray[i].basename === basename && projectarray[i].project_type === "text") {
+                  standardexists = true;
+              }
+          }
+
+          for (i = 0; i < selections.length; i++) {
+              if (selections[i].source === "ulb") {
+                  typearray.push({name: "Text - " + selections[i].name, code: "text", resource: selections[i].source, allowed: true, fullname: basename});
+              } else {
+                  typearray.push({name: "Text - " + selections[i].name, code: "text", resource: selections[i].source, allowed: true, fullname: project + "_" + selections[i].source + "-" + language.id});
+              }
+          }
+          typearray.push({name: "Notes", code: "tn", resource: "", allowed: standardexists, fullname: project + "_tn-" + language.id});
+          typearray.push({name: "Questions", code: "tq", resource: "", allowed: standardexists, fullname: project + "_tq-" + language.id});
+
+          for (i = 0; i < typearray.length; i++) {
+              for (var k = 0; k < projectarray.length; k++) {
+                  if (projectarray[k].fullname === typearray[i].fullname) {
+                      typearray[i].allowed = false;
+                  }
+              }
+          }
+
+          this.set('typelist', typearray);
+      },
+
+      checkclass: function (allowed) {
+          return allowed ? 'row' : 'row unavailable';
       },
 
       checkobs: function (name) {
@@ -170,7 +213,7 @@
       },
 
       store: function(e) {
-          this.type = e.model.type.code;
+          this.type = e.model.type;
           this.fire('create');
       },
 

--- a/app/elements/ts-translate/ts-target/ts-target-edit.html
+++ b/app/elements/ts-translate/ts-target/ts-target-edit.html
@@ -79,7 +79,7 @@
         <paper-material elevation="1">
             <div id="heading">
                 <div>
-                    <span>[[chunk.meta.chunkref]]</span> - <span>[[chunk.data.target_language.name]]</span>
+                    <span>[[chunk.meta.chunkref]]</span> - <span>[[chunk.data.target_language.name]]</span> - <span>[[chunk.data.resource_id]]</span>
                 </div>
                 <paper-icon-button icon="done" on-tap="review"></paper-icon-button>
             </div>

--- a/app/elements/ts-translate/ts-target/ts-target-review.html
+++ b/app/elements/ts-translate/ts-target/ts-target-review.html
@@ -87,7 +87,7 @@
         <paper-material id="main" elevation="1">
             <div id="heading">
                 <div>
-                    <span>[[chunk.meta.chunkref]]</span> - <span>[[chunk.data.target_language.name]]</span>
+                    <span>[[chunk.meta.chunkref]]</span> - <span>[[chunk.data.target_language.name]]</span> - <span>[[chunk.data.resource_id]]</span>
                 </div>
                 <template is="dom-if" if="{{!chunk.completed}}">
                     <paper-icon-button icon="create" title="edit" on-tap="edit"></paper-icon-button>

--- a/app/elements/ts-translate/ts-target/ts-target-view.html
+++ b/app/elements/ts-translate/ts-target/ts-target-view.html
@@ -58,7 +58,7 @@
         <paper-material elevation="1">
             <div id="heading">
                 <div>
-                    <span>[[chunk.chapterref]]</span> &mdash; <span>[[chunk.data.target_language.name]]</span>
+                    <span>[[chunk.chapterref]]</span> &mdash; <span>[[chunk.data.target_language.name]]</span> - <span>[[chunk.data.resource_id]]</span>
                 </div>
             </div>
             <div id="content" class="editmode">

--- a/app/js/projects.js
+++ b/app/js/projects.js
@@ -514,6 +514,7 @@ function ProjectsManager(query, configurator) {
                 target_language: meta.target_language,
                 project_id: meta.project_id,
                 project_type: meta.project_type,
+                resource_id: meta.resource_id,
                 source_translations: sources,
                 translators: meta.translators,
                 finished_frames: finishedFrames,


### PR DESCRIPTION
This should complete issue #256 with the file naming convention last agreed upon (ulb text standard translation keep base naming convention without any extensions)  The app is setup to automatically update manifest files of any older or imported projects.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-desktop/265)
<!-- Reviewable:end -->
