### PR TITLE
Backup location added to setting page

### DIFF
--- a/app/config/user-setting.json
+++ b/app/config/user-setting.json
@@ -58,12 +58,12 @@
         "visible": true
     },
     {
-        "name": "savedirectory",
-        "mainText": "Save Directory",
-        "value": "test",
+        "name": "backuplocation",
+        "mainText": "Backup Location",
+        "value": "",
         "group": "advanced",
         "enabled": true,
-        "visible": false
+        "visible": true
     },
     {
         "name": "logginglevel",

--- a/app/elements/ts-main/ts-dashboard.html
+++ b/app/elements/ts-main/ts-dashboard.html
@@ -160,9 +160,8 @@
           <ts-terms accepted="{{accepted}}"></ts-terms>
       </template>
 
-      <input type="file" class="hide" id="restore" accept=".tstudio" multiple>
-
-      <input class="hide" id="backup" type="file" nwsaveas="" />
+      <input id="restore" class="hide" type="file" accept=".tstudio" multiple />
+      <input id="backup" class="hide" type="file" nwsaveas="" />
 
       <paper-dialog id="feedback" class="popup" modal="true" entry-animation="scale-up-animation" exit-animation="scale-down-animation">
           <div id="feedbackheader">
@@ -259,6 +258,10 @@
           tempbackup: {
               type: Object,
               value: {}
+          },
+          backuptimerid: {
+              type: Number,
+              value: -1
           }
       },
 
@@ -272,8 +275,10 @@
           var confirm = this.$.confirm;
 
           backup.value = null;
-          backup.nwsaveas = name;
+          backup.nwworkingdir = App.configurator.getUserSetting('backuplocation');
+          backup.nwsaveas = backup.nwworkingdir + App.configurator.PATH_SEP + name;
           backup.addEventListener("change", function (evt) {
+             // console.log('change');
               if (firsttime) {
                   firsttime = false;
                   var filename = backup.value;
@@ -289,6 +294,7 @@
               }
           }, false);
           backup.click();
+          this.stopautobackup();
       },
 
       executebackup: function () {
@@ -328,6 +334,7 @@
           var chooser = this.$.restore;
           chooser.value = null;
           chooser.addEventListener('change', function(evt) {
+             // console.log('change');
               mythis.set('options.body', "Restoring.  Please wait...");
               mythis.set('options.loading', true);
               loading.open();
@@ -355,15 +362,28 @@
               }
           }, false);
           chooser.click();
+          this.stopautobackup();
       },
 
       openfeedback: function () {
           this.feedback = "";
           this.$.feedback.open();
+          this.stopautobackup();
       },
 
       closefeedback: function () {
           this.$.feedback.close();
+          // console.log('close feedback');
+          this.startautobackup();
+      },
+
+      // NOTE: This function was removed by someone else. I put this back here to resolve a merge conflict.
+      //    If really not needed, please let me (Vicky) know before you delete it. I was planning to use it
+      //    as a hook for the autobackup.
+      closeconfirm: function () {
+          this.$.confirm.close();
+          // console.log('close confirm');
+          this.startautobackup();
       },
 
       sendfeedback: function () {
@@ -381,11 +401,15 @@
                   mythis.set('options.title', "Feedback Sent");
                   mythis.set('options.body', "Your feedback has been successfully sent.  Thanks.");
                   mythis.set('options.loading', false);
+                  // console.log('send feedback succeed');
+                  mythis.startautobackup();
               });
           } else {
               mythis.set('options.title', "Feedback Failed");
               mythis.set('options.body', "You are not set up with a token to send feedback.");
               mythis.set('options.loading', false);
+              // console.log('send feedback failed');
+              mythis.startautobackup();
           }
       },
 
@@ -393,6 +417,13 @@
           var el = this.querySelector('[data-route="' + this.route + '"]');
           // The async delay prevents a flicker. It's a UI thing, not a logic thing.
           el && el.forceResize && this.async(el.forceResize.bind(el), 30);
+
+          // console.log('route changed');
+          if (this.route === 'translate') {
+             this.startautobackup();
+          } else {
+             this.stopautobackup();
+          }
       },
 
       updatelist: function () {
@@ -476,6 +507,18 @@
 
       setdefault: function () {
           this.currentproject = {};
+      },
+
+      startautobackup: function() {
+         this.backuptimerid = App.projectsManager.startAutoBackup();
+         // console.log(this.backuptimerid);
+      },
+
+      stopautobackup: function() {
+         if (this.backuptimerid > 0) {
+            App.projectsManager.stopAutoBackup(this.backuptimerid);
+            this.backuptimerid = -1;
+         }
       },
 
       ready: function() {

--- a/app/elements/ts-settings/ts-settings.html
+++ b/app/elements/ts-settings/ts-settings.html
@@ -69,6 +69,9 @@
             --paper-checkbox-checked-color: var(--accent-color-dark);
             --paper-checkbox-unchecked-color: var(--accent-color-dark);
         }
+        .hide {
+            display: none;
+        }
     </style>
 
     <template>
@@ -104,6 +107,8 @@
             </template>
 
         </div>
+
+        <input id="backup-location-browser" name="backup-location-browser" class="hide" type="file" nwdirectory directory on-change="_updateBackupLocation"/>
 
     </template>
 
@@ -158,6 +163,7 @@
 
         ready: function() {
             this.settings = App.configurator.getUserSettingArr();
+            this.$['backup-location-browser'].nwworkingdir = App.configurator.getUserSetting('backuplocation');
         },
 
         back: function() {
@@ -165,7 +171,7 @@
         },
 
         _isVisible: function(bool) {
-            if (bool == undefined) bool = true;
+            if (bool === undefined) { bool = true; }
             return bool;
         },
 
@@ -177,7 +183,7 @@
 
         _computeHelpText: function(setting) {
             var text;
-            if (typeof(setting.base.value) === "number" && setting.base.helpText) {
+            if (typeof setting.base.value === "number" && setting.base.helpText) {
                 text = setting.base.helpText.replace("<int>", setting.base.value);
             }
             else {
@@ -187,20 +193,25 @@
         },
 
         _isBoolean: function(value) {
-            return typeof(value) == 'boolean';
+            return typeof value === 'boolean';
         },
 
         _runTapHandler: function(event) {
-            if (event.model.setting.name == 'developertools') {
+            var name = event.model.setting.name;
+            var value = event.model.setting.value;
+            if (name === 'developertools') {
                 App.showDevTools();
             }
-            else if (event.model.setting.name == "refreshsettings") {
+            else if (name === "refreshsettings") {
                 this.settings = App.configurator.refreshUserSetting();
                 this.saveSettings();
             }
-            else if (typeof (event.model.setting.value) == 'boolean') {
+            else if (name === "backuplocation") {
+                document.querySelector('#backup-location-browser').click();
+            }
+            else if (typeof value === 'boolean') {
                 var path = 'settings.' + event.target.dataGroup + '.list.' + event.target.dataList + '.value';
-                this.set(path, !event.model.setting.value);
+                this.set(path, !value);
                 this.saveSettings();
             }
             else {
@@ -219,6 +230,15 @@
 
         _onSettingCancel: function() {
             this.closeSettingModal();
+        },
+
+        _updateBackupLocation: function() {
+            var newPath = this.$['backup-location-browser'].value;
+            if (newPath) {
+                var oldPath = App.configurator.getUserSetting('backuplocation');
+                this.settings = App.configurator.setUserSetting('backuplocation', newPath);
+                App.projectsManager.migrateBackup(oldPath, newPath);
+            }
         },
 
         openSettingModal: function(event) {
@@ -240,7 +260,7 @@
             modal.fire('open');
             modal.addEventListener('setting-confirm', this._onSettingConfirm.bind(this, path, event.target.id));
             modal.addEventListener('setting-cancel', this._onSettingCancel.bind(this));
-            return modal
+            return modal;
         },
 
         closeSettingModal: function() {

--- a/app/elements/ts-translate/ts-translate.html
+++ b/app/elements/ts-translate/ts-translate.html
@@ -1322,7 +1322,6 @@
             setTimeout(function() {
                 mythis.selected = 3;
             }, 500);
-
         },
 
         gohome: function () {

--- a/app/js/bootstrap.js
+++ b/app/js/bootstrap.js
@@ -10,6 +10,7 @@
     let mainWindow = gui.Window.get();
     let path = require('path');
     let fs = require('fs');
+    let mkdirp = require('mkdirp');
     let Reporter = require('../js/reporter').Reporter;
 
     let date = new Date();
@@ -188,7 +189,6 @@
             });
         },
 
-
         /**
          * Loads read-only and default configuration settings
          */
@@ -208,8 +208,25 @@
             _this.configurator.loadConfig(defaults);
             _this.configurator.setValue('rootDir', gui.App.dataPath, {'mutable':false});
             _this.configurator.setValue('targetTranslationsDir', path.join(gui.App.dataPath, 'targetTranslations'), {'mutable':false});
+            // NOTE: Do we need these tempDir and indexDir? I don't see them being created.
             _this.configurator.setValue('tempDir', path.join(gui.App.dataPath, 'temp'), {'mutable':false});
             _this.configurator.setValue('indexDir', path.join(gui.App.dataPath, 'index'), {'mutable':false});
+
+            let backuplocation = _this.configurator.getUserSetting('backuplocation');
+            // Empty backuplocation means it hasn't been setup, or been deleted previously.
+            if (backuplocation === "" || backuplocation === undefined || !App.util.isValidPath(backuplocation)) {
+                console.warn('Backup location contains bad value. Resetting backup location.');
+                let defaultLocation = path.join(process.env['HOME'], App.appName, 'backup');
+                _this.configurator.setUserSetting('backuplocation', defaultLocation);
+                mkdirp(defaultLocation, function(err) {
+                    if (err) {
+                        console.error(err);
+                    } else {
+                        console.log(defaultLocation + ' is created.');
+                    }
+                });
+            }
+
         },
 
         /**

--- a/app/js/configurator.js
+++ b/app/js/configurator.js
@@ -8,6 +8,7 @@
     'use strict';
 
     let _ = require('lodash');
+    let path = require('path');
     let userSetting = require('../config/user-setting');
 
     function Configurator () {
@@ -119,6 +120,8 @@
             });
         };
 
+        /**
+         */
         let flattenUserSetting = function(settingArr) {
             var flatSetting = [];
 
@@ -131,6 +134,8 @@
             return flatSetting;
         };
 
+        /**
+         */
         let fontSizeMap = {
             'normal': '100%',
             'small': '90%',
@@ -144,6 +149,12 @@
         // This is the returned object
         // 
         let configurator = {
+
+            /**
+             */
+            get PATH_SEP() {
+                return path.sep;
+            },
 
             /**
              * Fetch the raw and default setting array from JSON file
@@ -195,17 +206,37 @@
              * @return value of the user setting
              */
             getUserSetting: function(name) {
-                var s = this.getUserSettingArr();
-                var list = _.find(s, {'list': [{'name': name}]}).list;
-                return _.find(list, {'name': name}).value;
+                try {
+                    var s = this.getUserSettingArr();
+                    var list = _.find(s, {'list': [{'name': name}]}).list;
+                    return _.find(list, {'name': name}).value;     
+                } catch (e) { console.error(e); }
             },
 
+            /**
+             * Set the value of a setting
+             * @param name: of the user setting
+             * @return value of the user setting
+             */
+            setUserSetting: function(name, value) {
+                try {
+                    var s = this.getUserSettingArr();
+                    var listIndex = _.findIndex(s, {'list': [{'name': name}]});
+                    var settingIndex = _.findIndex(s[listIndex].list, {'name': name});
+                    s[listIndex].list[settingIndex].value = value;
+                    this.saveUserSettingArr(s);
+                    return s;
+                } catch (e) { console.error(e); }
+            },
+
+            /**
+             */
             refreshUserSetting: function() {
                 var defaults = this._userSetting();
                 var current = [];
                 try {
                     current = flattenUserSetting(JSON.parse(storage['user-setting']));
-                } catch (e) { }                
+                } catch (e) { console.error(e); }
 
                 // Keep current values and remove non-existent settings
                 for (var i in current) {
@@ -236,7 +267,7 @@
             applyPrefBehavior: function() {
                 // We may not need this as settings that affects behavior is most likely called
                 //    using the App.configurator.getUserSetting(key) API.
-                console.log('Pretend to apply behavior');
+                // console.log('Pretend to apply behavior');
             },
 
             /**

--- a/app/js/lib/util.js
+++ b/app/js/lib/util.js
@@ -10,6 +10,28 @@
         _ = require('lodash');
 
     /**
+     * NOTE: Determines if a string is a valid path
+     * @param string: the string to be tested
+     */
+    function isValidPath(string) {
+        string = string.replace(/\//g, '\\');
+        var os = process.platform;
+        var win_path = /^(((\\\\([^\\/:\*\?"\|<>\. ]+))|([a-zA-Z]:\\))(([^\\/:\*\?"\|<>\. ]*)([\\]*))*)$/;
+        var linux_path = /^[\/]*([^\/\\ \:\*\?"<\>\|\.][^\/\\\:\*\?\"<\>\|]{0,63}\/)*$/;
+        var isValid = false;
+
+        if (os === 'win64' || os === 'win32') {
+            isValid = win_path.test(string);
+        } else if (os === 'linux' || os === 'darwin') {
+            isValid = linux_path.test(string);
+        } else {
+            console.warn('OS is not recognized', os);
+        }
+
+        return isValid;
+    }
+
+    /**
      * Raises an exception along with some context to provide better debugging
      * @param e the exception to be raised
      * @param args arguments to be added to the exception message
@@ -45,6 +67,9 @@
         }).replace(/\s+/g, '');
     }
 
+    /*
+     * NOTE: Need doc
+     */
     function promisify (module, fn) {
         var f = module ? module[fn] : fn;
 
@@ -76,7 +101,6 @@
      *  and creates a curried function.
      *
      */
-
     function guard (method) {
         return function (cb) {
             var visit = typeof cb === 'function' ? function (v) { return cb(v); } : cb;
@@ -86,6 +110,9 @@
         };
     }
 
+    /*
+     * NOTE: Need doc
+     */
     function log () {
         if (process.env.NODE_ENV !== 'test') {
             console.log.apply(console, arguments);
@@ -168,6 +195,7 @@
         });
     }
 
+    exports.isValidPath = isValidPath;
     exports.download = download;
     exports.raiseWithContext = raiseWithContext;
     exports.removeDiacritics = diacritics.removeDiacritics;

--- a/app/js/projects.js
+++ b/app/js/projects.js
@@ -23,7 +23,7 @@ function zipper (r) {
 var map = guard('map'),
     indexBy = guard('indexBy'),
     flatten = guard('flatten'),
-    filter = guard('filter'),
+    // filter = guard('filter'),  // Never used
     compact = guard('compact');
 
 /**
@@ -34,8 +34,8 @@ var map = guard('map'),
 
 function ProjectsManager(query, configurator) {
 
-    var puts = console.log.bind(console),
-        write = wrap(fs, 'writeFile'),
+    // var puts = console.log.bind(console),  // Never used
+    var write = wrap(fs, 'writeFile'),
         read = wrap(fs, 'readFile'),
         mkdirp = wrap(null, mkdirP),
         rm = wrap(null, rimraf),
@@ -373,6 +373,48 @@ function ProjectsManager(query, configurator) {
             });
         },
 
+        /*
+         * Moves (using utils function) .tstudio files from the old to the new path
+         * @param oldPath: source backup directory
+         * @param newPath: target backup directory
+         */
+        migrateBackup: function(oldPath, newPath) {
+            var tstudioFiles = [];
+            readdir(oldPath, function(err, files) {
+                if (err) { console.log(err); }
+                tstudioFiles = files.filter(function(f) {
+                    // Only return files with .tstudio extensions
+                    return f.split('.').pop() === 'tstudio';
+                });
+                tstudioFiles.forEach(function(f) {
+                    var oldFilePath = oldPath + path.sep + f;
+                    var newFilePath = newPath + path.sep + f;
+                    utils.move(oldFilePath, newFilePath, function(err) {
+                        if (err) { console.log(err); }
+                    });
+                });
+            });
+        },
+
+        // fakeBackup: function() {
+        //     console.log('Backing up...');
+        // },
+
+        /*
+         */
+        startAutoBackup: function() {
+            // console.log('Auto Backup has start');
+            // return window.setInterval(this.fakeBackup, 3000);
+        },
+
+        /*
+         */
+        stopAutoBackup: function(id) {
+            // console.log('stopping id', id);
+            // window.clearInterval(id);
+            // console.log('Auto Backup is stopped');
+        },
+
         /**
          *
          * @param translation an array of frames
@@ -482,7 +524,7 @@ function ProjectsManager(query, configurator) {
 
                         fs.writeFile(filename + '.txt', new Buffer(chapterContent));
                         resolve(true);
-                    }else {
+                    } else {
                         // we don't support anything but dokuwiki and usx right now
                         reject('We only support exporting OBS and USX projects for now');
                     }


### PR DESCRIPTION
Resolves issue #205 

- Changed the name for the setting from 'savedirectory' to
  'backuplocation' in user-setting.json because it's more accurate.

- Set initial value of 'backuplocation' to home directory in configurator.js
- Added 'setUserSetting()' for configurator.js API

- Create backup folder if needed when bootstrapping
- Browse folder when selecting backup location in settings
- Preserve value for backup location when user changes it

- Open backup to the location in settings

- Migrate .tstudio files when changing
- Skeleton for auto backup

- Removed uneeded part of skeleton for autobackup

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-desktop/350)
<!-- Reviewable:end -->
