### PR TITLE
Force refresh when settings page is ready

### DIFF
--- a/app/elements/ts-settings/ts-settings.html
+++ b/app/elements/ts-settings/ts-settings.html
@@ -157,7 +157,7 @@
         },
 
         ready: function() {
-            this.settings = App.configurator.getUserSettingArr();
+            this.settings = App.configurator.refreshUserSetting();
         },
 
         back: function() {


### PR DESCRIPTION
Simple solution to the issue mentioned in #340 of refreshing user setting by default.

Should be merged in after #350 and #351

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-desktop/352)
<!-- Reviewable:end -->
