### PR TITLE
Issue 327 printing cutoff fix

### DIFF
--- a/src/js/printer.js
+++ b/src/js/printer.js
@@ -201,7 +201,12 @@ function Printer() {
                                         //console.debug(frame);
                                         // TRICKY: right now all images are en
                                         var imgPath = path.join(imagePath, meta.resource_id + "-en-" + frame.meta.chapterid + "-" + frame.meta.frameid + ".jpg");
-                                        doc.image(imgPath, {width:doc.page.width - 72*2});
+                                        //check the position of the text on the page. 
+                                        // 792 (total ht of page) - 50 ( lower margin) - 263.25 (height of pic) = 478.75 (max amount of space used before image)
+                                        if(doc.y > 478.75){
+                                            doc.addPage();
+                                        }
+                                       doc.image(imgPath, {width:doc.page.width - 72*2});
                                     }
                                     doc.moveDown()
                                         .fontSize(10)


### PR DESCRIPTION
To fix issue #327 
Added a check to the targetTranslationToPDF function in printer.js. The current position of text on the page is checked and if it is below a certain position a new page is added before placing an image on the page.

Instead of using hardcoded numbers, I could look into using the imagesize library to get the height of the image from the url if we think images of varying sizes will be used in the future.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-desktop/372)
<!-- Reviewable:end -->
