### PR TITLE
Major overhaul of migrate/restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translationstudio",
   "productName": "translationStudio",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A utility for translating the Bible and biblical content into any language.",
   "keywords": [],
   "homepage": "https://github.com/unfoldingWord-dev/ts-desktop",

--- a/src/elements/ts-main/ts-dashboard.html
+++ b/src/elements/ts-main/ts-dashboard.html
@@ -345,12 +345,15 @@
 
       updatelist: function () {
           var mythis = this;
-          App.projectsManager.loadTargetTranslationsList().then(function(list) {
+          App.projectsManager.migrateTargetTranslationsList()
+              .then(function () {
+                  return App.projectsManager.loadTargetTranslationsList()
+              })
+              .then(function(list) {
               App.ipc.send('loading-status', 'Updating Manifest Files...');
               for (var i = 0; i < list.length; i++) {
                   list[i] = App.projectsManager.updateManifestToMeta(list[i]);
               }
-              // TRICKY: remove invalid manifests (null)
               mythis.set('projectlist', _.compact(list));
 
               App.ipc.send('loading-status', 'Checking Auto Backups...');
@@ -367,11 +370,11 @@
       },
 
       ready: function() {
-          App.ipc.send('loading-status', 'Loading Projects List...');
-          this.updatelist();
           this.setdefault();
           App.ipc.send('loading-status', 'Retrieving User Info...');
           this.retrieveuser();
+          App.ipc.send('loading-status', 'Loading Projects List...');
+          this.updatelist();
       }
 
   });

--- a/src/js/migration/targetTranslationMigrator.js
+++ b/src/js/migration/targetTranslationMigrator.js
@@ -7,7 +7,30 @@
         fs = require('fs'),
         rimraf = require('rimraf'),
         utils = require('../../js/lib/util'),
-        jsonfile = require('jsonfile');
+        jsonfile = require('jsonfile'),
+        readjson = utils.promisify(jsonfile, 'readFile'),
+        writejson = utils.promisify(jsonfile, 'writeFile');
+
+    function migrateAll (list) {
+        let p = Promise.resolve(false);
+        let results = [];
+        _.forEach(list, function (paths) {
+            p = p.then(function () {
+                return migrate(paths)
+                    .catch(function (err) {
+                        console.log(err);
+                        return false;
+                    }).then(function (result) {
+                        results.push(result);
+                    });
+            })
+        });
+
+        return p.then(function () {
+            return _.compact(results);
+        })
+    }
+
     /**
      * Performs the nessesary migrations on a target translation.
      * Migrations should always pass through in order to collect all needed updates
@@ -16,325 +39,312 @@
      * @returns {Promise.<boolean>} true if migration was successful
      */
     function migrate (paths) {
-        return new Promise(function(resolve, reject) {
-            try {
 
-                jsonfile.readFile(paths.manifest, function(readErr, manifest) {
-                    if(readErr !== null) {
-                        reject('failed to read the manifest ' + readErr);
-                    } else {
-                        let project = {manifest: manifest, paths: paths};
-                        let packageVersion = project.manifest.package_version;
-                        switch (packageVersion) {
-                            case 2:
-                                project = v2(project);
-                            case 3:
-                                project = v3(project);
-                            case 4:
-                                project = v4(project);
-                            case 5:
-                                project = v5(project);
-                            case 6:
-                                project = v6(project);
-                                break;
-                            default:
-                                reject('unsupported package version "' + packageVersion + '"');
-                        }
+        var readManifest = function (paths) {
+            return readjson(paths.manifest).then(function (manifest) {
+                manifest.package_version = manifest.package_version || 2;
+                return {manifest: manifest, paths: paths};
+            })
+        };
 
-                        // update generator
-                        project.manifest.generator.name = 'ts-desktop';
-                        // TODO: update build number
+        var migrateV2 = function (project) {
+            let manifest = project.manifest;
+            let paths = project.paths;
 
-                        // save manifest
-
-                        jsonfile.writeFile(project.paths.manifest, project.manifest, {spaces:2}, function (writeErr) {
-                            if(writeErr !== null) {
-                                reject('failed to update the manifest: ' + writeErr);
-                            } else {
-                                resolve(project);
-                            }
-                        });
+            if (manifest.package_version <= 2) {
+                // finished frames
+                manifest.finished_frames = [];
+                _.forEach(manifest.frames, function(finished, frame) {
+                    if(finished) {
+                        manifest.finished_frames.push(frame);
                     }
                 });
-            } catch (err) {
-                reject('failed to migrate target translation: ' + err);
-            }
-        });
+                delete manifest.frames;
 
-    }
+                // finished chapter titles/references
+                manifest.finished_titles = [];
+                manifest.finished_references = [];
+                _.forEach(manifest.chapters, function(state, chapter) {
+                    if(state.finished_title) {
+                        manifest.finished_titles.push(chapter);
+                    }
+                    if(state.finished_reference) {
+                        manifest.finished_references.push(chapter);
+                    }
+                });
+                delete manifest.chapters;
 
-    /**
-     * current version
-     * @param project {object}
-     * @retusn {object}
-     */
-    function v6(project) {
-        return project;
-    }
+                // project id
+                manifest.project_id = manifest.slug;
+                delete manifest.slug;
 
-    /**
-     * renaming the folder with new file naming convention, remove ready file,
-     * update tw and ta id's, update local storage values to new naming, remove
-     * backups with old names
-     * @param project {object}
-     * @returns {object}
-     */
+                // target language
+                manifest.target_language.id = manifest.target_language.slug;
+                delete manifest.target_language.slug;
 
-    function v5(project) {
-        let manifest = project.manifest;
-        let paths = project.paths;
-        let oldname = paths.projectDir.substring(paths.projectDir.lastIndexOf(path.sep) + 1);
-        if (manifest.project.id === "tw") {
-            manifest.project.id = "bible";
-            manifest.project.name = "translationWords";
-        }
-        if (manifest.project.id === "ta") {
-            manifest.project.id = "vol1";
-            manifest.project.name = "translationAcademy Vol 1";
-        }
-        let unique_id = manifest.target_language.id + "_" + manifest.project.id + "_" + manifest.type.id;
-        if (manifest.resource.id !== "") {
-            unique_id += "_" + manifest.resource.id;
-        }
-        let newpath = path.join(paths.parentDir, unique_id);
-        let localstorageitems = ["-chapter", "-index", "-selected", "-completion", "-source"];
-        let backupDir = App.configurator.getUserPath('datalocation', 'automatic_backups');
-        let oldbackup = path.join(backupDir, oldname);
-        let readyfile = path.join(paths.projectDir, 'READY');
-        let srcDir = path.resolve(path.join(__dirname, '../..'));
-        let license = fs.readFileSync(path.join(srcDir, 'assets', 'LICENSE.md'));
-
-        fs.writeFileSync(paths.license, license);
-        rimraf.sync(readyfile);
-        rimraf.sync(oldbackup);
-        fs.renameSync(paths.projectDir, newpath);
-
-        for (var i = 0; i < localstorageitems.length; i++) {
-            App.configurator.setValue(unique_id + localstorageitems[i], App.configurator.getValue(oldname + localstorageitems[i]));
-            App.configurator.unsetValue(oldname + localstorageitems[i]);
-        }
-
-        paths.projectDir = newpath;
-        paths.manifest = path.join(newpath, 'manifest.json');
-
-        // update package version
-        manifest.package_version = 6;
-
-        return {manifest: manifest, paths: paths};
-    }
-
-    /**
-     * major restructuring of the manifest to provide better support for future front/back matter, drafts, rendering,
-     * and solves issues between desktop and android platforms.
-     * @param project {object}
-     * @returns {object}
-     */
-    function v4(project) {
-        let manifest = project.manifest;
-        let dir = project.paths.projectDir;
-        // translation type
-        let typeId = _.get(manifest, 'project.type', 'text').toLowerCase();
-        let typeNames = {
-            text: 'Text',
-            tn: 'Notes',
-            tq: 'Questions',
-            tw: 'Words',
-            ta: 'Academy'
-        };
-        if(_.has(manifest, 'project.type')) {
-            delete manifest.project.type;
-        }
-        manifest.type = {
-            id: typeId,
-            name: _.get(typeNames, typeId, '')
-        };
-
-        // update project
-        // NOTE: this was actually in v3 but we missed it so we need to catch it here
-        if(_.has(manifest, 'project_id')) {
-            manifest.project = {
-                id: manifest.project_id,
-                name: ""
-            };
-            delete manifest.project_id;
-        }
-
-        // update resource
-        let resourceNames = {
-            ulb: 'Unlocked Literal Bible',
-            udb: 'Unlocked Dynamic Bible',
-            obs: 'Open Bible Stories',
-            reg: 'Regular'
-        };
-        if(_.has(manifest, 'resource_id')) {
-            let resourceId =_.get(manifest, 'resource_id', 'reg');
-            delete manifest.resource_id;
-            manifest.resource = {
-                id: resourceId,
-                name: _.get(resourceNames, resourceId, '')
-            };
-        } else if(!_.has(manifest, 'resource')) {
-            // add missing resource
-            if(_.get(manifest, 'type.id') === 'text') {
-                let resourceId =_.get(manifest, 'project.id') === 'obs' ? 'obs' : 'reg';
-                manifest.resource = {
-                    id: resourceId,
-                    name: _.get(resourceNames, resourceId, '')
-                };
-            }
-        }
-
-        // update source translations
-        manifest.source_translations = _.values(_.mapValues(manifest.source_translations, function(value, key) {
-            let parts = key.split('-');
-            if(parts.length > 2) {
-                let languageResourceId = key.substring(parts[0].length + 1, key.length);
-                let pieces = languageResourceId.split('-');
-                if(pieces.length > 0) {
-                    let resourceId = pieces[pieces.length - 1];
-                    value.resource_id = resourceId;
-                    value.language_id = languageResourceId.substring(0, languageResourceId.length - resourceId.length - 1);
+                // add placeholders
+                manifest.package_version = 3;
+                if(!manifest.hasOwnProperty('translators')) {
+                    manifest.translators = [];
+                }
+                if(!manifest.hasOwnProperty('source_translations')) {
+                    manifest.source_translations = {};
                 }
             }
-            return value;
-        }));
 
-        // update parent draft
-        if(_.has(manifest, 'parent_draft_resource_id')) {
-            manifest.parent_draft = {
-                resource_id: manifest.parent_draft_resource_id,
-                checking_entity: '',
-                checking_level: '',
-                comments: 'The parent draft is unknown',
-                contributors: '',
-                publish_date: '',
-                source_text: '',
-                source_text_version: '',
-                version: ''
-            };
-            delete manifest.parent_draft_resource_id;
-        }
+            return {manifest: manifest, paths: paths};
+        };
 
-        // update finished chunks
-        manifest.finished_chunks = _.get(manifest, 'finished_frames', []);
-        delete manifest.finished_frames;
+        var migrateV3 = function (project) {
+            let manifest = project.manifest;
+            let paths = project.paths;
 
-        // remove finished titles
-        _.forEach(_.get(manifest, 'finished_titles'), function(value, index) {
-            let finishedChunks = _.get(manifest, 'finished_chunks', []);
-            finishedChunks.push(value + '-title');
-            manifest.finished_chunks = _.unique(finishedChunks);
-        });
-        delete manifest.finished_titles;
-
-        // remove finished references
-        _.forEach(_.get(manifest, 'finished_references'), function(value, index) {
-            let finishedChunks = _.get(manifest, 'finished_chunks', []);
-            finishedChunks.push(value + '-reference');
-            manifest.finished_chunks = _.unique(finishedChunks);
-        });
-        delete manifest.finished_references;
-
-        // remove project components
-        _.forEach(_.get(manifest, 'finished_project_components'), function(value, index) {
-            let finishedChunks = _.get(manifest, 'finished_chunks', []);
-            finishedChunks.push('00-'+value);
-            manifest.finished_chunks = _.unique(finishedChunks);
-        });
-        delete manifest.finished_project_components;
-
-        // add format
-        if(!_.has(manifest, 'format') || manifest.format === 'usx' || manifest.format === 'default') {
-            manifest.format = _.get(manifest, 'type.id', 'text') !== 'text' || _.get(manifest, 'project.id') === 'obs' ? 'markdown' : 'usfm';
-        }
-
-        // update package version
-        manifest.package_version = 5;
-
-        // update where project title is saved
-        let oldProjectTitlePath = path.join(dir, 'title.txt');
-        let projectTranslationDir = path.join(dir, '00');
-        let newProjectTitlePath = path.join(projectTranslationDir, 'title.txt');
-        if(fs.existsSync(oldProjectTitlePath)) {
-            try {
-                fs.mkdirSync(projectTranslationDir);
-            } catch (e) {
-                console.log(e);
+            if (manifest.package_version <= 3) {
+                // flatten translators to an array of names
+                manifest.translators = _.unique(_.map(_.values(manifest.translators), function(obj) {
+                    return typeof obj === 'string' ? obj : obj.name;
+                }));
             }
-            let projectTitle = fs.readFileSync(oldProjectTitlePath).toString();
-            fs.writeFileSync(newProjectTitlePath, projectTitle);
-            fs.unlink(oldProjectTitlePath);
-        }
 
-        return {manifest: manifest, paths: project.paths};
-    }
+            return {manifest: manifest, paths: paths};
+        };
 
-    /**
-     * We changed how translator information is stored
-     * we no longer store sensitive information like email and phone number
-     * we added a project_type
-     * @param project {object}
-     * @returns {object}
-     */
-    function v3(project) {
-        let manifest = project.manifest;
-        // flatten translators to an array of names
-        manifest.translators = _.unique(_.map(_.values(manifest.translators), function(obj) {
-            return typeof obj === 'string' ? obj : obj.name;
-        }));
-        return {manifest: manifest, paths: project.paths};
-    }
+        var migrateV4 = function (project) {
+            let manifest = project.manifest;
+            let paths = project.paths;
 
-    /**
-     * updated structure of finished frames, chapter titles/references, project id, and target language id
-     *
-     * @param project {object}
-     * @returns {object} the migrated manifest or null
-     */
-    function v2(project) {
-        let manifest = project.manifest;
+            if (manifest.package_version <= 4) {
+                let dir = project.paths.projectDir;
+                // translation type
+                let typeId = _.get(manifest, 'project.type', 'text').toLowerCase();
+                let typeNames = {
+                    text: 'Text',
+                    tn: 'Notes',
+                    tq: 'Questions',
+                    tw: 'Words',
+                    ta: 'Academy'
+                };
+                if(_.has(manifest, 'project.type')) {
+                    delete manifest.project.type;
+                }
+                manifest.type = {
+                    id: typeId,
+                    name: _.get(typeNames, typeId, '')
+                };
 
-        // finished frames
-        manifest.finished_frames = [];
-        _.forEach(manifest.frames, function(finished, frame) {
-            if(finished) {
-                manifest.finished_frames.push(frame);
+                // update project
+                // NOTE: this was actually in v3 but we missed it so we need to catch it here
+                if(_.has(manifest, 'project_id')) {
+                    manifest.project = {
+                        id: manifest.project_id,
+                        name: ""
+                    };
+                    delete manifest.project_id;
+                }
+
+                // update resource
+                let resourceNames = {
+                    ulb: 'Unlocked Literal Bible',
+                    udb: 'Unlocked Dynamic Bible',
+                    obs: 'Open Bible Stories',
+                    reg: 'Regular'
+                };
+                if(_.has(manifest, 'resource_id')) {
+                    let resourceId =_.get(manifest, 'resource_id', 'reg');
+                    delete manifest.resource_id;
+                    manifest.resource = {
+                        id: resourceId,
+                        name: _.get(resourceNames, resourceId, '')
+                    };
+                } else if(!_.has(manifest, 'resource')) {
+                    // add missing resource
+                    if(_.get(manifest, 'type.id') === 'text') {
+                        let resourceId =_.get(manifest, 'project.id') === 'obs' ? 'obs' : 'reg';
+                        manifest.resource = {
+                            id: resourceId,
+                            name: _.get(resourceNames, resourceId, '')
+                        };
+                    }
+                }
+
+                // update source translations
+                manifest.source_translations = _.values(_.mapValues(manifest.source_translations, function(value, key) {
+                    let parts = key.split('-');
+                    if(parts.length > 2) {
+                        let languageResourceId = key.substring(parts[0].length + 1, key.length);
+                        let pieces = languageResourceId.split('-');
+                        if(pieces.length > 0) {
+                            let resourceId = pieces[pieces.length - 1];
+                            value.resource_id = resourceId;
+                            value.language_id = languageResourceId.substring(0, languageResourceId.length - resourceId.length - 1);
+                        }
+                    }
+                    return value;
+                }));
+
+                // update parent draft
+                if(_.has(manifest, 'parent_draft_resource_id')) {
+                    manifest.parent_draft = {
+                        resource_id: manifest.parent_draft_resource_id,
+                        checking_entity: '',
+                        checking_level: '',
+                        comments: 'The parent draft is unknown',
+                        contributors: '',
+                        publish_date: '',
+                        source_text: '',
+                        source_text_version: '',
+                        version: ''
+                    };
+                    delete manifest.parent_draft_resource_id;
+                }
+
+                // update finished chunks
+                manifest.finished_chunks = _.get(manifest, 'finished_frames', []);
+                delete manifest.finished_frames;
+
+                // remove finished titles
+                _.forEach(_.get(manifest, 'finished_titles'), function(value, index) {
+                    let finishedChunks = _.get(manifest, 'finished_chunks', []);
+                    finishedChunks.push(value + '-title');
+                    manifest.finished_chunks = _.unique(finishedChunks);
+                });
+                delete manifest.finished_titles;
+
+                // remove finished references
+                _.forEach(_.get(manifest, 'finished_references'), function(value, index) {
+                    let finishedChunks = _.get(manifest, 'finished_chunks', []);
+                    finishedChunks.push(value + '-reference');
+                    manifest.finished_chunks = _.unique(finishedChunks);
+                });
+                delete manifest.finished_references;
+
+                // remove project components
+                _.forEach(_.get(manifest, 'finished_project_components'), function(value, index) {
+                    let finishedChunks = _.get(manifest, 'finished_chunks', []);
+                    finishedChunks.push('00-'+value);
+                    manifest.finished_chunks = _.unique(finishedChunks);
+                });
+                delete manifest.finished_project_components;
+
+                // add format
+                if(!_.has(manifest, 'format') || manifest.format === 'usx' || manifest.format === 'default') {
+                    manifest.format = _.get(manifest, 'type.id', 'text') !== 'text' || _.get(manifest, 'project.id') === 'obs' ? 'markdown' : 'usfm';
+                }
+
+                // update package version
+                manifest.package_version = 5;
+
+                // update where project title is saved
+                let oldProjectTitlePath = path.join(dir, 'title.txt');
+                let projectTranslationDir = path.join(dir, '00');
+                let newProjectTitlePath = path.join(projectTranslationDir, 'title.txt');
+                if(fs.existsSync(oldProjectTitlePath)) {
+                    try {
+                        fs.mkdirSync(projectTranslationDir);
+                    } catch (e) {
+                        console.log(e);
+                    }
+                    let projectTitle = fs.readFileSync(oldProjectTitlePath).toString();
+                    fs.writeFileSync(newProjectTitlePath, projectTitle);
+                    fs.unlinkSync(oldProjectTitlePath);
+                }
             }
-        });
-        delete manifest.frames;
 
-        // finished chapter titles/references
-        manifest.finished_titles = [];
-        manifest.finished_references = [];
-        _.forEach(manifest.chapters, function(state, chapter) {
-            if(state.finished_title) {
-                manifest.finished_titles.push(chapter);
+            return {manifest: manifest, paths: paths};
+        };
+
+        var migrateV5 = function (project) {
+            let manifest = project.manifest;
+            let paths = project.paths;
+
+            if (manifest.package_version <= 5) {
+                let oldname = paths.projectDir.substring(paths.projectDir.lastIndexOf(path.sep) + 1);
+                if (manifest.project.id === "tw") {
+                    manifest.project.id = "bible";
+                    manifest.project.name = "translationWords";
+                }
+                if (manifest.project.id === "ta") {
+                    manifest.project.id = "vol1";
+                    manifest.project.name = "translationAcademy Vol 1";
+                }
+                let unique_id = manifest.target_language.id + "_" + manifest.project.id + "_" + manifest.type.id;
+                if (manifest.resource.id !== "") {
+                    unique_id += "_" + manifest.resource.id;
+                }
+                let oldpath = path.join(paths.parentDir, oldname);
+                let newpath = path.join(paths.parentDir, unique_id);
+                let localstorageitems = ["-chapter", "-index", "-selected", "-completion", "-source"];
+                let backupDir = App.configurator.getUserPath('datalocation', 'automatic_backups');
+                let oldbackup = path.join(backupDir, oldname);
+                let readyfile = path.join(paths.projectDir, 'READY');
+                let srcDir = path.resolve(path.join(__dirname, '../..'));
+                let license = fs.readFileSync(path.join(srcDir, 'assets', 'LICENSE.md'));
+
+                fs.writeFileSync(paths.license, license);
+                rimraf.sync(readyfile);
+                rimraf.sync(oldbackup);
+
+                for (var i = 0; i < localstorageitems.length; i++) {
+                    App.configurator.setValue(unique_id + localstorageitems[i], App.configurator.getValue(oldname + localstorageitems[i]));
+                    App.configurator.unsetValue(oldname + localstorageitems[i]);
+                }
+
+                paths.projectDir = newpath;
+                paths.manifest = path.join(newpath, 'manifest.json');
+                paths.license = path.join(newpath, 'LICENSE.md');
+
+                // update package version
+                manifest.package_version = 6;
+
+                return utils.mkdirp(newpath).then(function () {
+                    return utils.move(oldpath, newpath, {clobber: true}).then(function () {
+                        return {manifest: manifest, paths: paths};
+                    });
+                });
             }
-            if(state.finished_reference) {
-                manifest.finished_references.push(chapter);
+
+            return {manifest: manifest, paths: paths};
+        };
+
+        var migrateV6 = function (project) {
+            let manifest = project.manifest;
+            let paths = project.paths;
+
+            if (manifest.package_version <= 6) {
+                //add code here to migrate to v7
             }
-        });
-        delete manifest.chapters;
 
-        // project id
-        manifest.project_id = manifest.slug;
-        delete manifest.slug;
+            return {manifest: manifest, paths: paths};
+        };
 
-        // target language
-        manifest.target_language.id = manifest.target_language.slug;
-        delete manifest.target_language.slug;
+        var checkVersion = function (project) {
+            if (project.manifest.package_version !== 6) {
+                throw new Error("Failed to migrate project");
+            }
+            return project;
+        };
 
-        // add placeholders
-        manifest.package_version = 3;
-        if(!manifest.hasOwnProperty('translators')) {
-            manifest.translators = [];
-        }
-        if(!manifest.hasOwnProperty('source_translations')) {
-            manifest.source_translations = {};
-        }
+        var saveManifest = function (project) {
+            let manifest = project.manifest;
+            let paths = project.paths;
 
-        return {manifest: manifest, paths: project.paths};
+            manifest.generator.name = 'ts-desktop';
+            // TODO: update build number
+
+            return writejson(paths.manifest, manifest, {spaces:2}).then(utils.ret({manifest: manifest, paths: paths}));
+        };
+
+        return readManifest(paths)
+            .then(migrateV2)
+            .then(migrateV3)
+            .then(migrateV4)
+            .then(migrateV5)
+            .then(migrateV6)
+            .then(checkVersion)
+            .then(saveManifest)
+
     }
 
     exports.migrate = migrate;
+    exports.migrateAll = migrateAll;
 }());

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -574,17 +574,12 @@ function ProjectsManager(query, configurator, srcDir) {
                         return {parentDir, projectDir, manifest, license};
                     });
                 })
-                .then(function (list) {
-                    var migrated = _.map(list, function (paths) {
-                        return targetTranslationMigrator.migrate(paths)
-                            .catch(function (err) {
-                                console.log(err);
-                                return false;
-                            });
-                    });
-                    return Promise.all(migrated).then(function (result) {
-                        return _.compact(result);
-                    })
+                .then(targetTranslationMigrator.migrateAll)
+                .then(function (results) {
+                    if (!results.length) {
+                        throw new Error ("Could not restore this project");
+                    }
+                    return results;
                 })
                 .then(function (results) {
                     return _.map(results, function (result) {
@@ -812,19 +807,28 @@ function ProjectsManager(query, configurator, srcDir) {
 
             return this.loadProjectsList()
                 .then(map(makePaths))
+                .then(map('manifest'))
                 .then(function (list) {
-                    var migrated = _.map(list, function (paths) {
-                        return targetTranslationMigrator.migrate(paths)
-                            .catch(function (err) {
-                                console.log(err);
-                                return false;
-                            });
-                    });
-                    return Promise.all(migrated).then(function (result) {
-                        return _.compact(result);
+                    return _.filter(list, function (path) {
+                        try {
+                            var test = fs.statSync(path);
+                        } catch (e) {
+                            test = false;
+                        }
+                        return test;
                     })
                 })
-                .then(map('manifest'))
+                .then(map(read))
+                .then(Promise.all.bind(Promise))
+                .then(map(fromJSON))
+        },
+
+        migrateTargetTranslationsList: function () {
+            var makePaths = config.makeProjectPathsForProject.bind(config);
+
+            return this.loadProjectsList()
+                .then(map(makePaths))
+                .then(targetTranslationMigrator.migrateAll)
         },
 
         loadFinishedFramesList: function (meta) {

--- a/src/views/splash-screen.html
+++ b/src/views/splash-screen.html
@@ -30,12 +30,20 @@
     #text {
     	position: absolute;
 		right: 36px;
-		font-size: 29px;
 		color: #444;
 		top: 59px;
 		font-weight: 300;
 		letter-spacing: 2px;
 		font-family: Roboto, sans-serif;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+    #title {
+        font-size: 29px;
+    }
+    #version {
+        font-size: 18px;
     }
     #status {
 		position: absolute;
@@ -56,13 +64,20 @@
 </head>
 <body>
     <img src="../../icons/icon-big.png">
-    <div id="text">translationStudio</div>
+    <div id="text">
+        <p id="title">translationStudio</p>
+        <p id="version">Version <span id="versiontext"></span></p>
+    </div>
     <div id="status"><span id="status-text">Loading...</span></div>
 
     <script>
     (function () {
     	var ipcRenderer = require('electron').ipcRenderer,
+            versiontext = document.getElementById('versiontext'),
     		statusText = document.getElementById('status-text');
+
+        var p = require('../../package');
+        versiontext.innerHTML = p.version;
 
     	ipcRenderer.on('loading-status', function (event, status) {
     		statusText.innerHTML = status;


### PR DESCRIPTION
Fixes #507 #511, #480 .

Changes in this pull request:
-Major rewrite of migrator module in order to use Promises and async functions
-Add version 2 to old projects
-Add error checking to catch projects that don't restore properly
Setup migration to handle projects with same name