### PR TITLE
Hotfix: fixed failure to start due to auto backups crash

### DIFF
--- a/src/elements/ts-main/ts-dashboard.html
+++ b/src/elements/ts-main/ts-dashboard.html
@@ -555,6 +555,10 @@
                   App.ipc.send('loading-status', 'Creating Auto Backups...');
                   return App.exportManager.backupAllTranslations(list, autobackupdir)
               })
+              .catch(function (err) {
+                  console.error(err);
+                  App.reporter.logError(err);
+              })
               .then(function () {
                   mythis.set('busy', false);
                   setTimeout(function() {


### PR DESCRIPTION
The app was failing to start because it would crash on the auto backups during load (if there was a corrupt manifest or project). The error is now caught and logged via the Reporter, and the app starts normally.
